### PR TITLE
feat: add Dockerfile for Linux backend deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,27 @@
+FROM --platform=linux/amd64 python:3.11-slim
+
+# Install uv
+RUN pip install uv
+
+WORKDIR /app
+
+# Copy local dependencies (relative to project root)
+COPY eudplib-0.80.6-cp310-abi3-linux_x86_64.whl /eudplib-0.80.6-cp310-abi3-linux_x86_64.whl
+COPY wengine/ /wengine/
+
+# Copy backend source
+COPY backend/ /app/
+
+# Install dependencies
+RUN uv sync --no-dev
+
+# Copy preprocess output (tileset static data)
+# tileset.py resolves 6 parent dirs up from its location to reach project root
+COPY preprocess/output/ /preprocess/output/
+
+# Create required runtime directories
+RUN mkdir -p /app/output /app/logs /app/static
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "uv run uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-eudplib = { path = "../eudplib-0.80.0-cp310-abi3-macosx_11_0_arm64.whl", marker = "platform_system == 'Linux'" }
+eudplib = { path = "../eudplib-0.80.6-cp310-abi3-linux_x86_64.whl", marker = "platform_system == 'Linux'" }
 wengine = { path = "../wengine", editable = true }
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Add Dockerfile targeting Linux (x86_64) environment
- Add eudplib Linux wheel (`eudplib-0.80.6-cp310-abi3-linux_x86_64.whl`)
- Update `pyproject.toml` eudplib path to Linux wheel
- Support `PORT` env variable for Railway deployment

## Test plan
- [x] `docker build -f backend/Dockerfile -t webditor-backend .` builds successfully
- [x] `docker run -p 8000:8000 webditor-backend` runs and `GET /` returns expected response

🤖 Generated with [Claude Code](https://claude.com/claude-code)